### PR TITLE
Fix segmentation fault

### DIFF
--- a/src/countminsketch.c
+++ b/src/countminsketch.c
@@ -147,6 +147,8 @@ CMSketch *GetCMSketch(RedisModuleCtx *ctx, RedisModuleKey *key) {
   s->ha = (unsigned int *)&dma[off];
   off += sizeof(unsigned int) * s->d;
   s->hb = (unsigned int *)&dma[off];
+
+  return s;
 }
 
 /* CMS.INITBYDIM key width depth


### PR DESCRIPTION
This PR fixes segmentation fault in calling commands with keys to existing sketches. The error is caused by `GetCMSketch` function that does not work as expected since it never returns any value.
