### PR TITLE
Return the correct code on load

### DIFF
--- a/src/countminsketch.c
+++ b/src/countminsketch.c
@@ -405,5 +405,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx) {
     return REDISMODULE_ERR;
   if (RedisModule_CreateCommand(ctx, "cms.test", TestModule, "write deny-oom",
                                 0, 0, 0) == REDISMODULE_ERR)
-    return REDISMODULE_OK;
+    return REDISMODULE_ERR;
+
+  return REDISMODULE_OK;
 }


### PR DESCRIPTION
The current `RedisModule_OnLoad` can return nothing on success or `REDISMODULE_OK` on error. This PR fixes it to return the correct code.
