### PR TITLE
Fix memory allocation and initialization

### DIFF
--- a/src/countminsketch.c
+++ b/src/countminsketch.c
@@ -91,11 +91,9 @@ long long ustime(void) {
 /* Creates a new sketch based with given dimensions. */
 CMSketch *NewCMSketch(RedisModuleCtx *ctx, RedisModuleKey *key, int width,
                       int depth) {
-  size_t slen = strlen(CMS_SIGNATURE) + sizeof(long long) +  // count
-                sizeof(int) +                                // width
-                sizeof(int) +                                // depth
-                sizeof(int) * width * depth +                // vector
-                sizeof(unsigned int) * 2 * depth;            // hashes
+  size_t slen = strlen(CMS_SIGNATURE) + sizeof(CMSketch) +
+                sizeof(int) * width * depth +     // vector
+                sizeof(unsigned int) * 2 * depth; // hashes
 
   if (RedisModule_StringTruncate(key, slen) != REDISMODULE_OK) {
     RedisModule_ReplyWithError(ctx,
@@ -113,7 +111,7 @@ CMSketch *NewCMSketch(RedisModuleCtx *ctx, RedisModuleKey *key, int width,
   s->c = 0;
   s->w = width;
   s->d = depth;
-  off += sizeof(long long) + sizeof(int) * 2;
+  off += sizeof(CMSketch);
   s->v = (int *)&dma[off];
   off += sizeof(int) * width * depth;
   s->ha = (unsigned int *)&dma[off];
@@ -141,7 +139,7 @@ CMSketch *GetCMSketch(RedisModuleCtx *ctx, RedisModuleKey *key) {
   }
 
   CMSketch *s = (CMSketch *)&dma[off];
-  off += sizeof(long long) + sizeof(int) * 2;
+  off += sizeof(CMSketch);
   s->v = (int *)&dma[off];
   off += sizeof(int) * s->w * s->d;
   s->ha = (unsigned int *)&dma[off];


### PR DESCRIPTION
The current `NewCMSketch` and `GetCMSketch` functions have an issue in memory allocation and initialization.

Let `s` be a pointer to `CMSketch`. Though `s->v` should have been initialized to the address of the vector of counts, it is actually initialized to the address of `s->v` itself. This can be confirmed as follows:

```
redis 127.0.0.1:6379> cms.initbydim cms 1 1
OK
redis 127.0.0.1:6379> cms.query cms x
1) (integer) 1631790454
```

This `cms.query` should have returned `0`.

This PR fixes this issue by allocating a little bit more memory to store the pointers separately from the vector and hashes.
