### PR TITLE
Use a fixed seed

### DIFF
--- a/src/countminsketch.c
+++ b/src/countminsketch.c
@@ -64,6 +64,7 @@
 #define RLMODULE_DESC "An approximate frequency counter"
 
 #define CMS_SIGNATURE "COUNTMINSKETCH:1.0:"
+#define CMS_SEED 0
 
 #define MAGIC 2147483647  // 2^31-1 according to the paper
 
@@ -118,7 +119,7 @@ CMSketch *NewCMSketch(RedisModuleCtx *ctx, RedisModuleKey *key, int width,
   off += sizeof(unsigned int) * depth;
   s->hb = (unsigned int *)&dma[off];
 
-  srand(ustime());
+  srand(CMS_SEED);
   for (int i = 0; i < s->d; i++) {
     s->ha[i] = rand() & MAGIC;
     s->hb[i] = rand() & MAGIC;

--- a/src/countminsketch.c
+++ b/src/countminsketch.c
@@ -18,36 +18,6 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/*
-* Includes 'ustime' from redis/src/server.c
-* Copyright (c) 2009-2012, Salvatore Sanfilippo <antirez at gmail dot com>
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-*   * Redistributions of source code must retain the above copyright notice,
-*     this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above copyright
-*     notice, this list of conditions and the following disclaimer in the
-*     documentation and/or other materials provided with the distribution.
-*   * Neither the name of Redis nor the names of its contributors may be used
-*     to endorse or promote products derived from this software without
-*     specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*/
-
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
@@ -77,17 +47,6 @@ typedef struct CMSketch {
   int *v;
   unsigned int *ha, *hb;
 } CMSketch;
-
-/* Return the UNIX time in microseconds */
-long long ustime(void) {
-  struct timeval tv;
-  long long ust;
-
-  gettimeofday(&tv, NULL);
-  ust = ((long long)tv.tv_sec) * 1000000;
-  ust += tv.tv_usec;
-  return ust;
-}
 
 /* Creates a new sketch based with given dimensions. */
 CMSketch *NewCMSketch(RedisModuleCtx *ctx, RedisModuleKey *key, int width,


### PR DESCRIPTION
This PR proposes to fix a seed to make coefficients consistent for every sketch.

For now, there is no way to create sketches that share the same coefficients. That is needed to implement binary operations like addition/subtraction on sketches.

It might be acceptable to fix a seed since Redis itself constantly uses a fixed seed for its HLL data type, and unlike hash tables, the choice of the seed does not affect the time complexity of any operations.
